### PR TITLE
ConvertorFactory from config, GenereerZaakIdentificatie implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,22 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,26 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+
+        <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/javax.activation/activation -->
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/nl/haarlem/translations/zdstozgw/config/Configuratie.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/config/Configuratie.java
@@ -17,4 +17,7 @@ public class Configuratie {
     @SerializedName("documentTypes")
     @Expose
     public List<DocumentType> documentTypes = null;
+    @SerializedName("translations")
+    @Expose    
+    public List<Translation> translations = null;
 }

--- a/src/main/java/nl/haarlem/translations/zdstozgw/config/Translation.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/config/Translation.java
@@ -1,0 +1,24 @@
+package nl.haarlem.translations.zdstozgw.config;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class Translation {
+    @SerializedName("translation")
+    @Expose
+    public String translation;
+    @SerializedName("soapaction")
+    @Expose
+    public String soapaction;
+    @SerializedName("requestcontains")
+    @Expose
+    public String requestcontains;
+    @SerializedName("template")
+    @Expose
+    public String template;
+    @SerializedName("implementation")
+    @Expose
+    public String implementation;
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/controller/SoapController.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/controller/SoapController.java
@@ -33,7 +33,16 @@ public class SoapController {
     private ZaakService zaakService;
 
     private String response = "NOT IMPLEMENTED";
-
+   
+    @PostMapping(value = "/VrijBerichtService", consumes = MediaType.TEXT_XML_VALUE, produces = MediaType.TEXT_XML_VALUE)
+    public String vrijBerichtService(@RequestHeader(name = "SOAPAction", required = true) String soapAction, @RequestBody String body) {
+        var convertor = ConvertorFactory.getConvertor(soapAction.replace("\"", ""), body);        
+        if (convertor != null) {
+        	this.response = convertor.Convert(zaakService, new StufRequest(XmlUtils.convertStringToDocument(body)));        	
+        }
+        return this.response;        
+    }    
+    
     @PostMapping(value = "/BeantwoordVraag", consumes = MediaType.TEXT_XML_VALUE, produces = MediaType.TEXT_XML_VALUE)
     public String beantwoordVraag(@RequestBody String body) {
 

--- a/src/main/java/nl/haarlem/translations/zdstozgw/controller/SoapController.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/controller/SoapController.java
@@ -1,6 +1,7 @@
 package nl.haarlem.translations.zdstozgw.controller;
 
 import nl.haarlem.translations.zdstozgw.convertor.ConvertorFactory;
+import nl.haarlem.translations.zdstozgw.jpa.ApplicationParameterRepository;
 import nl.haarlem.translations.zdstozgw.convertor.Convertor;
 import nl.haarlem.translations.zdstozgw.translation.zds.model.*;
 import nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService;
@@ -31,6 +32,8 @@ public class SoapController {
 
     @Autowired
     private ZaakService zaakService;
+	@Autowired	
+	protected ApplicationParameterRepository repository;
 
     private String response = "NOT IMPLEMENTED";
    
@@ -38,7 +41,7 @@ public class SoapController {
     public String vrijBerichtService(@RequestHeader(name = "SOAPAction", required = true) String soapAction, @RequestBody String body) {
         var convertor = ConvertorFactory.getConvertor(soapAction.replace("\"", ""), body);        
         if (convertor != null) {
-        	this.response = convertor.Convert(zaakService, new StufRequest(XmlUtils.convertStringToDocument(body)));        	
+        	this.response = convertor.Convert(zaakService, repository, new StufRequest(XmlUtils.convertStringToDocument(body)));        	
         }
         return this.response;        
     }    
@@ -98,12 +101,12 @@ public class SoapController {
         if (soapAction.contains("creeerZaak")) {
             ZakLk01_v2 zakLk01_v2r = getZakLka01(body);
             convertor = ConvertorFactory.getConvertor(soapAction, zakLk01_v2r.stuurgegevens.zender.applicatie);
-            response = convertor.Convert(zaakService, zakLk01_v2r);
+            response = convertor.Convert(zaakService, repository, zakLk01_v2r);
         }
         if (soapAction.contains("voegZaakdocumentToe")) {
             EdcLk01 edcLk01 = getZakLEdcLk01(body);
             convertor = ConvertorFactory.getConvertor(soapAction, edcLk01.stuurgegevens.zender.applicatie);
-            response = convertor.Convert(zaakService, edcLk01);
+            response = convertor.Convert(zaakService, repository, edcLk01);
         }
 
 

--- a/src/main/java/nl/haarlem/translations/zdstozgw/convertor/Convertor.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/convertor/Convertor.java
@@ -1,0 +1,9 @@
+package nl.haarlem.translations.zdstozgw.convertor;
+import nl.haarlem.translations.zdstozgw.translation.zds.model.StufRequest;
+import nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService;
+
+public interface Convertor {
+
+	String Convert(ZaakService zaakService, Object object);
+
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/convertor/Convertor.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/convertor/Convertor.java
@@ -1,9 +1,10 @@
 package nl.haarlem.translations.zdstozgw.convertor;
+import nl.haarlem.translations.zdstozgw.jpa.ApplicationParameterRepository;
 import nl.haarlem.translations.zdstozgw.translation.zds.model.StufRequest;
 import nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService;
 
 public interface Convertor {
 
-	String Convert(ZaakService zaakService, Object object);
+	String Convert(ZaakService zaakService, ApplicationParameterRepository repository, Object object);
 
 }

--- a/src/main/java/nl/haarlem/translations/zdstozgw/convertor/ConvertorFactory.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/convertor/ConvertorFactory.java
@@ -1,34 +1,71 @@
 package nl.haarlem.translations.zdstozgw.convertor;
 
+import java.lang.invoke.MethodHandles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import nl.haarlem.translations.zdstozgw.config.ConfigService;
+import nl.haarlem.translations.zdstozgw.config.Translation;
 import nl.haarlem.translations.zdstozgw.convertor.impl.CreeerZaak;
 import nl.haarlem.translations.zdstozgw.convertor.impl.VoegZaakdocumentToe;
 
 public class ConvertorFactory {
 
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static ConfigService config = null; 
+    
+    static{
+		try {
+	    	// cannot be done inline, ConfigService can throw an exception
+			config = new ConfigService();
+		} 
+		catch (Exception ex) {
+			log.error("Could not load the configuration", ex);
+		}    	
+    }    
+    
   	public static Convertor getConvertor(String soapAction, String application) {
 
 		String classname = null;
 		String templatepath = null;
 	
-		switch(soapAction) 
-        { 
-    		case "genereerZaakIdentificatie_Di02": 		
-        	case "http://www.egem.nl/StUF/sector/zkn/0310/genereerZaakIdentificatie_Di02":
-        		classname = "nl.sudwestfryslan.translations.zdstozgw.implementation.GenereerZaakIdentificatie";
-        		templatepath = "src\\main\\java\\nl\\sudwestfryslan\\translations\\zdstozgw\\implementation\\genereerZaakIdentificatie_Du02.xml";
+		for (Translation translation : config.getConfiguratie().getTranslations() ){
+			if(translation.soapaction.equals(soapAction) && application.contains(translation.requestcontains)) {
+        		classname = translation.implementation;
+        		templatepath = translation.template;	
+        		log.info("Using translation: '" + translation.translation + "' for soapaction:" + soapAction);
         		break;
-        	case "http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01":    			
-        	case "creeerZaak_ZakLk01":
-        		classname = CreeerZaak.class.getName();
-        		templatepath = "--template-zit-in-de-code--";
+			}
+		}
+		// START-FALLBACK-OBSOLETE: the old code from getConvertor()		
+		if(classname == null) {
+			log.warn("Fallback for soapaction:" + soapAction + " with application:" + application);
+
+			switch(soapAction) 
+	        {  
+	    		case "genereerZaakIdentificatie_Di02": 		
+	        	case "http://www.egem.nl/StUF/sector/zkn/0310/genereerZaakIdentificatie_Di02":
+	        		classname = "nl.sudwestfryslan.translations.zdstozgw.implementation.GenereerZaakIdentificatie";
+	        		templatepath = "src\\main\\java\\nl\\sudwestfryslan\\translations\\zdstozgw\\implementation\\genereerZaakIdentificatie_Du02.xml";
         		break;
-        	case "http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01":
-        		classname = VoegZaakdocumentToe.class.getName();
-        		templatepath = "--template-zit-in-de-code--";
-        		break;
-        	default: 
-            	return null;
+	        	case "http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01":    			
+	        	case "creeerZaak_ZakLk01":
+	        		classname = CreeerZaak.class.getName();
+	        		templatepath = "--template-zit-in-de-code--";
+	        		break;
+	        	case "http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01":
+	        		classname = VoegZaakdocumentToe.class.getName();
+	        		templatepath = "--template-zit-in-de-code--";
+	        		break;
+	        	default: 
+	            	return null;
         }
+		}		
+		// END-FALLBACK-OBSOLETE: the old code from getConvertor()		
+		
+		if(classname == null) {
+			return null;
+		}		
 		try {
 			Class<?> c = Class.forName(classname);
 			java.lang.reflect.Constructor<?> ctor = c.getConstructor(String.class);

--- a/src/main/java/nl/haarlem/translations/zdstozgw/convertor/ConvertorFactory.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/convertor/ConvertorFactory.java
@@ -1,0 +1,42 @@
+package nl.haarlem.translations.zdstozgw.convertor;
+
+import nl.haarlem.translations.zdstozgw.convertor.impl.CreeerZaak;
+import nl.haarlem.translations.zdstozgw.convertor.impl.VoegZaakdocumentToe;
+
+public class ConvertorFactory {
+
+  	public static Convertor getConvertor(String soapAction, String application) {
+
+		String classname = null;
+		String templatepath = null;
+	
+		switch(soapAction) 
+        { 
+    		case "genereerZaakIdentificatie_Di02": 		
+        	case "http://www.egem.nl/StUF/sector/zkn/0310/genereerZaakIdentificatie_Di02":
+        		classname = "nl.sudwestfryslan.translations.zdstozgw.implementation.GenereerZaakIdentificatie";
+        		templatepath = "src\\main\\java\\nl\\sudwestfryslan\\translations\\zdstozgw\\implementation\\genereerZaakIdentificatie_Du02.xml";
+        		break;
+        	case "http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01":    			
+        	case "creeerZaak_ZakLk01":
+        		classname = CreeerZaak.class.getName();
+        		templatepath = "--template-zit-in-de-code--";
+        		break;
+        	case "http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01":
+        		classname = VoegZaakdocumentToe.class.getName();
+        		templatepath = "--template-zit-in-de-code--";
+        		break;
+        	default: 
+            	return null;
+        }
+		try {
+			Class<?> c = Class.forName(classname);
+			java.lang.reflect.Constructor<?> ctor = c.getConstructor(String.class);
+			Object object = ctor.newInstance(new Object[] { templatepath });
+			return  (Convertor) object;
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}		
+	}		
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/CreeerZaak.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/CreeerZaak.java
@@ -1,6 +1,7 @@
 package nl.haarlem.translations.zdstozgw.convertor.impl;
 
 import nl.haarlem.translations.zdstozgw.convertor.Convertor;
+import nl.haarlem.translations.zdstozgw.jpa.ApplicationParameterRepository;
 import nl.haarlem.translations.zdstozgw.translation.zds.model.ZakLk01_v2;
 import nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService;
 
@@ -12,7 +13,7 @@ public class CreeerZaak implements Convertor {
     }
 
     @Override
-    public String Convert(ZaakService zaakService, Object object) {
+    public String Convert(ZaakService zaakService, ApplicationParameterRepository repository, Object object) {
         try {
 
             var zaak = zaakService.creeerZaak((ZakLk01_v2) object);

--- a/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/CreeerZaak.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/CreeerZaak.java
@@ -1,0 +1,33 @@
+package nl.haarlem.translations.zdstozgw.convertor.impl;
+
+import nl.haarlem.translations.zdstozgw.convertor.Convertor;
+import nl.haarlem.translations.zdstozgw.translation.zds.model.ZakLk01_v2;
+import nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService;
+
+public class CreeerZaak implements Convertor {
+    protected String templatePath;
+
+    public CreeerZaak(String templatePath) {
+        this.templatePath = templatePath;
+    }
+
+    @Override
+    public String Convert(ZaakService zaakService, Object object) {
+        try {
+
+            var zaak = zaakService.creeerZaak((ZakLk01_v2) object);
+            var bv03 = new nl.haarlem.translations.zdstozgw.translation.zds.model.Bv03();
+            bv03.setReferentienummer(zaak.getUuid());
+            return bv03.getSoapMessageAsString();
+
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            var f03 = new nl.haarlem.translations.zdstozgw.translation.zds.model.F03();
+            f03.setFaultString("Object was not saved");
+            f03.setCode("StUF046");
+            f03.setOmschrijving("Object niet opgeslagen");
+            f03.setDetails(ex.getMessage());
+            return f03.getSoapMessageAsString();
+        }
+    }
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/GenereerDocumentIdentificatie.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/GenereerDocumentIdentificatie.java
@@ -22,25 +22,25 @@ import nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService;
 
 import nl.haarlem.translations.zdstozgw.jpa.model.ApplicationParameter;
 
-public class GenereerZaakIdentificatie implements Convertor {
+public class GenereerDocumentIdentificatie implements Convertor {
 
 	@Data
-	private class GenereerZaakIdentificatie_Di02 {
+	private class GenereerDocumentIdentificatie_Di02 {
 	    final XpathDocument xpathDocument;
 	    Document document;
 	    
-		public GenereerZaakIdentificatie_Di02(StufRequest stufRequest) {
+		public GenereerDocumentIdentificatie_Di02(StufRequest stufRequest) {
 	        this.document = stufRequest.body;
 	        this.xpathDocument  = new XpathDocument(document);			
 		}
 	}
 	
 	@Data
-	private class GenereerZaakIdentificatie_Du02 {
+	private class GenereerDocumentIdentificatie_Du02 {
 	    final XpathDocument xpathDocument;
 	    Document document;
 
-		public GenereerZaakIdentificatie_Du02(String template) {
+		public GenereerDocumentIdentificatie_Du02(String template) {
 			this.document = nl.haarlem.translations.zdstozgw.utils.XmlUtils.getDocument(template);			
 			this.xpathDocument  = new XpathDocument(document);
 		}
@@ -49,7 +49,7 @@ public class GenereerZaakIdentificatie implements Convertor {
     private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());	
 	protected String template;
 	
-    public GenereerZaakIdentificatie(String template) {
+    public GenereerDocumentIdentificatie(String template) {
         this.template = template;
     }
 
@@ -58,14 +58,14 @@ public class GenereerZaakIdentificatie implements Convertor {
     	var stufRequest = (StufRequest) object;
     	DateFormat tijdstipformat = new SimpleDateFormat("yyyyMMddHHmmss");   	    
     	
-    	var prefixparam  = repository.getOne("ZaakIdentificatiePrefix");
-    	var idparam= repository.getOne("ZaakIdentificatieHuidige");    	
+    	var prefixparam  = repository.getOne("DocumentIdentificatiePrefix");
+    	var idparam= repository.getOne("DocumentIdentificatieHuidige");    	
     	var identificatie = Long.parseLong(idparam.getParameterValue()) + 1;	
     	idparam.setParameterValue(Long.toString(identificatie));
     	repository.save(idparam);
     	    	
-    	var di02 = new GenereerZaakIdentificatie_Di02(stufRequest);
-    	var du02 = new GenereerZaakIdentificatie_Du02(this.template); 	    	    	
+    	var di02 = new GenereerDocumentIdentificatie_Di02(stufRequest);
+    	var du02 = new GenereerDocumentIdentificatie_Du02(this.template); 	    	    	
     	du02.xpathDocument.setNodeValue(".//stuf:zender//stuf:organisatie", di02.xpathDocument.getNodeValue(".//stuf:ontvanger//stuf:organisatie"));
     	du02.xpathDocument.setNodeValue(".//stuf:zender//stuf:applicatie", di02.xpathDocument.getNodeValue(".//stuf:ontvanger//stuf:applicatie"));
     	du02.xpathDocument.setNodeValue(".//stuf:zender//stuf:gebruiker", di02.xpathDocument.getNodeValue(".//stuf:ontvanger//stuf:gebruiker"));

--- a/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/GenereerDocumentIdentificatie_Du02.xml
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/GenereerDocumentIdentificatie_Du02.xml
@@ -1,0 +1,25 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+	<s:Body>
+      <ZKN:genereerDocumentIdentificatie_Du02 xmlns:StUF="http://www.egem.nl/StUF/StUF0301" xmlns:ZKN="http://www.egem.nl/StUF/sector/zkn/0310" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+         <ZKN:stuurgegevens>
+            <StUF:berichtcode>Du02</StUF:berichtcode>
+			<StUF:zender>
+				<StUF:organisatie>${zenderOrganisatie}</StUF:organisatie>
+				<StUF:applicatie>${zenderApplicatie}</StUF:applicatie>
+				<StUF:gebruiker>${zenderGebruiker}</StUF:gebruiker>
+			</StUF:zender>
+			<StUF:ontvanger>
+				<StUF:organisatie>${ontvangerOrganisatie}</StUF:organisatie>
+				<StUF:applicatie>${ontvangerApplicatie}</StUF:applicatie>
+				<StUF:gebruiker>${ontvangerGebruiker}</StUF:gebruiker>
+			</StUF:ontvanger>
+			<StUF:referentienummer>${referentienummer}</StUF:referentienummer>
+			<StUF:tijdstipBericht>${tijdstipbericht}</StUF:tijdstipBericht>
+			<StUF:functie>genereerDocumentidentificatie</StUF:functie>
+		</ZKN:stuurgegevens>
+         <ZKN:document StUF:entiteittype="EDC" StUF:functie="entiteit">
+            <ZKN:identificatie>${documentidentificatie}</ZKN:identificatie>
+         </ZKN:document>
+      </ZKN:genereerDocumentIdentificatie_Du02>
+	</s:Body>
+</s:Envelope>

--- a/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/GenereerZaakIdentificatie.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/GenereerZaakIdentificatie.java
@@ -1,0 +1,69 @@
+package nl.haarlem.translations.zdstozgw.convertor.impl;
+
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.w3c.dom.Document;
+import lombok.Data;
+
+import nl.haarlem.translations.zdstozgw.translation.zds.model.StufRequest;
+import nl.haarlem.translations.zdstozgw.utils.XmlUtils;
+import nl.haarlem.translations.zdstozgw.utils.xpath.XpathDocument;
+import nl.haarlem.translations.zdstozgw.convertor.Convertor;
+import nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService;
+
+public class GenereerZaakIdentificatie implements Convertor {
+
+	@Data
+	private class GenereerZaakIdentificatie_Di02 {
+	    final XpathDocument xpathDocument;
+	    Document document;
+	    
+		public GenereerZaakIdentificatie_Di02(StufRequest stufRequest) {
+	        this.document = stufRequest.body;
+	        this.xpathDocument  = new XpathDocument(document);			
+		}
+	}
+	
+	@Data
+	private class GenereerZaakIdentificatie_Du02 {
+	    final XpathDocument xpathDocument;
+	    Document document;
+
+		public GenereerZaakIdentificatie_Du02(String template) {
+			this.document = nl.haarlem.translations.zdstozgw.utils.XmlUtils.getDocument(template);			
+			this.xpathDocument  = new XpathDocument(document);
+		}
+	}	
+	
+	protected String template;
+
+    public GenereerZaakIdentificatie(String template) {
+        this.template = template;
+    }
+
+    @Override
+    public String Convert(ZaakService zaakService, Object object) {
+    	var stufRequest = (StufRequest) object;
+    	DateFormat tijdstipformat = new SimpleDateFormat("yyyyMMddHHmmss");
+   	        
+    	// TODO: Wat is voorkeur manier om de laatst gegenereerde identifier persistent te maken?
+    	DateFormat identifierformat = new SimpleDateFormat("yyyyMMddHHmmssSS");
+    	var zaakidentifier = identifierformat.format(new Date());
+    	
+    	var di02 = new GenereerZaakIdentificatie_Di02(stufRequest);
+    	var du02 = new GenereerZaakIdentificatie_Du02(this.template); 	    	    	
+    	du02.xpathDocument.setNodeValue(".//stuf:zender//stuf:organisatie", di02.xpathDocument.getNodeValue(".//stuf:ontvanger//stuf:organisatie"));
+    	du02.xpathDocument.setNodeValue(".//stuf:zender//stuf:applicatie", di02.xpathDocument.getNodeValue(".//stuf:ontvanger//stuf:applicatie"));
+    	du02.xpathDocument.setNodeValue(".//stuf:zender//stuf:gebruiker", di02.xpathDocument.getNodeValue(".//stuf:ontvanger//stuf:gebruiker"));
+    	du02.xpathDocument.setNodeValue(".//stuf:ontvanger//stuf:organisatie", di02.xpathDocument.getNodeValue(".//stuf:zender//stuf:organisatie"));
+    	du02.xpathDocument.setNodeValue(".//stuf:ontvanger//stuf:applicatie", di02.xpathDocument.getNodeValue(".//stuf:zender//stuf:applicatie"));
+    	du02.xpathDocument.setNodeValue(".//stuf:ontvanger//stuf:gebruiker", di02.xpathDocument.getNodeValue(".//stuf:zender//stuf:gebruiker"));
+    	du02.xpathDocument.setNodeValue(".//stuf:referentienummer", di02.xpathDocument.getNodeValue(".//stuf:referentienummer"));    	
+    	du02.xpathDocument.setNodeValue(".//stuf:tijdstipBericht", tijdstipformat.format(new Date()));    
+    	du02.xpathDocument.setNodeValue(".//zkn:identificatie", zaakidentifier);
+    	
+    	return XmlUtils.xmlToString(du02.document);
+    }
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/GenereerZaakIdentificatie_Du02.xml
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/GenereerZaakIdentificatie_Du02.xml
@@ -1,0 +1,25 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+	<s:Body>
+		<ZKN:genereerZaakIdentificatie_Du02 xmlns:StUF="http://www.egem.nl/StUF/StUF0301" xmlns:ZKN="http://www.egem.nl/StUF/sector/zkn/0310" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+			<ZKN:stuurgegevens>
+				<StUF:berichtcode>Du02</StUF:berichtcode>
+				<StUF:zender>
+					<StUF:organisatie>${zenderOrganisatie}</StUF:organisatie>
+					<StUF:applicatie>${zenderApplicatie}</StUF:applicatie>
+					<StUF:gebruiker>${zenderGebruiker}</StUF:gebruiker>
+				</StUF:zender>
+				<StUF:ontvanger>
+					<StUF:organisatie>${ontvangerOrganisatie}</StUF:organisatie>
+					<StUF:applicatie>${ontvangerApplicatie}</StUF:applicatie>
+					<StUF:gebruiker>${ontvangerGebruiker}</StUF:gebruiker>
+				</StUF:ontvanger>
+				<StUF:referentienummer>${referentienummer}</StUF:referentienummer>
+				<StUF:tijdstipBericht>${tijdstipbericht}</StUF:tijdstipBericht>
+				<StUF:functie>genereerZaakidentificatie</StUF:functie>
+			</ZKN:stuurgegevens>
+			<ZKN:document StUF:entiteittype="ZAK" StUF:functie="entiteit">
+				<ZKN:identificatie>${zaakidentificatie}</ZKN:identificatie>
+			</ZKN:document>
+		</ZKN:genereerZaakIdentificatie_Du02>
+	</s:Body>
+</s:Envelope>

--- a/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/VoegZaakdocumentToe.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/VoegZaakdocumentToe.java
@@ -1,6 +1,7 @@
 package nl.haarlem.translations.zdstozgw.convertor.impl;
 
 import nl.haarlem.translations.zdstozgw.convertor.Convertor;
+import nl.haarlem.translations.zdstozgw.jpa.ApplicationParameterRepository;
 import nl.haarlem.translations.zdstozgw.translation.zds.model.EdcLk01;
 import nl.haarlem.translations.zdstozgw.translation.zds.model.ZakLk01_v2;
 import nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService;
@@ -14,7 +15,7 @@ public class VoegZaakdocumentToe implements Convertor {
     }
 
     @Override
-    public String Convert(ZaakService zaakService, Object object) {
+    public String Convert(ZaakService zaakService, ApplicationParameterRepository repository, Object object) {
         try {
 
             ZgwZaakInformatieObject zgwZaakInformatieObject = zaakService.voegZaakDocumentToe((EdcLk01) object);

--- a/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/VoegZaakdocumentToe.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/VoegZaakdocumentToe.java
@@ -1,0 +1,35 @@
+package nl.haarlem.translations.zdstozgw.convertor.impl;
+
+import nl.haarlem.translations.zdstozgw.convertor.Convertor;
+import nl.haarlem.translations.zdstozgw.translation.zds.model.EdcLk01;
+import nl.haarlem.translations.zdstozgw.translation.zds.model.ZakLk01_v2;
+import nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService;
+import nl.haarlem.translations.zdstozgw.translation.zgw.model.ZgwZaakInformatieObject;
+
+public class VoegZaakdocumentToe implements Convertor {
+    protected String templatePath;
+
+    public VoegZaakdocumentToe(String templatePath) {
+        this.templatePath = templatePath;
+    }
+
+    @Override
+    public String Convert(ZaakService zaakService, Object object) {
+        try {
+
+            ZgwZaakInformatieObject zgwZaakInformatieObject = zaakService.voegZaakDocumentToe((EdcLk01) object);
+            var bv03 = new nl.haarlem.translations.zdstozgw.translation.zds.model.Bv03();
+            bv03.setReferentienummer(zgwZaakInformatieObject.getUuid());
+            return bv03.getSoapMessageAsString();
+
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            var f03 = new nl.haarlem.translations.zdstozgw.translation.zds.model.F03();
+            f03.setFaultString("Object was not saved");
+            f03.setCode("StUF046");
+            f03.setOmschrijving("Object niet opgeslagen");
+            f03.setDetails(ex.getMessage());
+            return f03.getSoapMessageAsString();
+        }
+    }
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/jpa/ApplicationParameterRepository.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/jpa/ApplicationParameterRepository.java
@@ -1,0 +1,11 @@
+package nl.haarlem.translations.zdstozgw.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import nl.haarlem.translations.zdstozgw.jpa.model.ApplicationParameter;
+
+@Repository
+public interface ApplicationParameterRepository extends JpaRepository<ApplicationParameter, String> {
+ 	
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/jpa/model/ApplicationParameter.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/jpa/model/ApplicationParameter.java
@@ -1,0 +1,33 @@
+package nl.haarlem.translations.zdstozgw.jpa.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class ApplicationParameter {
+    @Id
+    private String parameterName;
+    private String parameterDescription;
+    private String parameterValue;
+    
+	public String getParameterName() {
+		return parameterName;
+	}
+	public void setParameterName(String parameterName) {
+		this.parameterName = parameterName;
+	}
+	public String getParameterDescription() {
+		return parameterDescription;
+	}
+	public void setParameterDescription(String parameterDescription) {
+		this.parameterDescription = parameterDescription;
+	}
+	public String getParameterValue() {
+		return parameterValue;
+	}
+	public void setParameterValue(String parameterValue) {
+		this.parameterValue = parameterValue;
+	}
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Gerelateerde.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Gerelateerde.java
@@ -1,0 +1,39 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.STUF;
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.ZKN;
+
+public class Gerelateerde {
+    @XmlElement(namespace = ZKN)
+    public String identificatie;
+
+    @XmlAttribute(namespace = STUF)
+    public String verwerkingssoort;
+
+    @XmlElement(namespace = ZKN)
+    public String omschrijving;
+
+    @XmlElement(namespace = ZKN)
+    public String code;
+
+    @XmlElement(namespace = ZKN)
+    public String ingangsdatumObject;
+
+    @XmlElement(namespace = ZKN, name = "zkt.code")
+    public String zktCode;
+
+    @XmlElement(namespace = ZKN, name = "zkt.omschrijving")
+    public String zktOmschrijving;
+
+    @XmlElement(namespace = ZKN)
+    public String volgnummer;
+
+    @XmlElement(namespace = ZKN)
+    public Medewerker medewerker;
+
+    @XmlElement(namespace = ZKN)
+    public NatuurlijkPersoon natuurlijkPersoon;
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/GerelateerdeWrapper.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/GerelateerdeWrapper.java
@@ -1,0 +1,15 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.ZKN;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class GerelateerdeWrapper {
+
+    @XmlElement(namespace = ZKN)
+    public Gerelateerde gerelateerde;
+
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Heeft.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Heeft.java
@@ -1,0 +1,22 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.ZKN;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Heeft {
+    @XmlElement(namespace = ZKN)
+    public Gerelateerde gerelateerde;
+
+    @XmlElement(namespace = ZKN)
+    public String datumStatusGezet;
+
+    @XmlElement(namespace = ZKN)
+    public String statustoelichting;
+
+    @XmlElement(namespace = ZKN)
+    public GerelateerdeWrapper isGezetDoor;
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/HeeftAlsInitiator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/HeeftAlsInitiator.java
@@ -1,0 +1,13 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.ZKN;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class HeeftAlsInitiator {
+    @XmlElement(namespace = ZKN)
+    public Gerelateerde gerelateerde;
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Inhoud.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Inhoud.java
@@ -1,0 +1,21 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlValue;
+
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.MIME;
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.STUF;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Inhoud{
+    @XmlAttribute(namespace = STUF)
+    public String bestandsnaam;
+
+    @XmlAttribute(namespace = MIME)
+    public String contentType;
+
+    @XmlValue()
+    public String value;
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Medewerker.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Medewerker.java
@@ -1,0 +1,16 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model;
+
+import javax.xml.bind.annotation.XmlElement;
+
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.ZKN;
+
+public class Medewerker {
+    @XmlElement(namespace = ZKN)
+    public String identificatie;
+
+    @XmlElement(namespace = ZKN)
+    public String achternaam;
+
+    @XmlElement(namespace = ZKN)
+    public String voorletters;
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/NatuurlijkPersoon.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/NatuurlijkPersoon.java
@@ -1,0 +1,32 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.BG;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class NatuurlijkPersoon {
+
+    @XmlElement(namespace = BG, name = "inp.bsn")
+    public String bsn;
+
+    @XmlElement(namespace = BG)
+    public String geslachtsnaam;
+
+    @XmlElement(namespace = BG)
+    public String voorvoegselGeslachtsnaam;
+
+    @XmlElement(namespace = BG)
+    public String voorletters;
+
+    @XmlElement(namespace = BG)
+    public String voornamen;
+
+    @XmlElement(namespace = BG)
+    public String geslachtsaanduiding;
+
+    @XmlElement(namespace = BG)
+    public String geboortedatum;
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Object.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Object.java
@@ -1,0 +1,36 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.STUF;
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.ZKN;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Object{
+    @XmlAttribute(namespace = STUF)
+    public String entiteittype;
+
+    @XmlElement(namespace = ZKN)
+    public String identificatie;
+
+    @XmlElement(namespace = ZKN)
+    public String omschrijving;
+
+//    niet in standaard?
+//    @XmlElement(namespace = ZKN)
+//    public String startdatum;
+
+    @XmlElement(namespace = ZKN)
+    public String registratiedatum;
+
+//      niet in standaard?
+//      @XmlElement(namespace = ZKN)
+//      public GerelateerdeWrapper isVan;
+
+    @XmlElement(namespace = ZKN)
+    public Heeft heeft;
+
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Ontvanger.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Ontvanger.java
@@ -1,0 +1,20 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.STUF;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Ontvanger{
+
+    @XmlElement(namespace = STUF)
+    public String organisatie;
+
+    @XmlElement(namespace = STUF)
+    public String applicatie;
+
+    @XmlElement(namespace = STUF)
+    public String gebruiker;
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/StufRequest.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/StufRequest.java
@@ -50,16 +50,16 @@ public class StufRequest {
         return new ZakLv01(xmlNodesToDocument(nodes, "geefLijstZaakdocumenten_ZakLa01"));
     }
 
-    public ZakLk01 getZakLk01() {
-        var nodes = body.getElementsByTagNameNS("http://www.stufstandaarden.nl/koppelvlak/zds0120", "creeerZaak_ZakLk01").item(0).getChildNodes();
+//    public ZakLk01 getZakLk01() {
+//        var nodes = body.getElementsByTagNameNS("http://www.egem.nl/StUF/sector/zkn/0310", "zakLk01").item(0).getChildNodes();
+//
+//        return new ZakLk01(xmlNodesToDocument(nodes, "creeerZaak_ZakLk01"));
+//    }
 
-        return new ZakLk01(xmlNodesToDocument(nodes, "creeerZaak_ZakLk01"));
-    }
-
-    public EdcLk01 getEdcLk01() {
-        var nodes = body.getElementsByTagNameNS("http://www.stufstandaarden.nl/koppelvlak/zds0120", "voegZaakdocumentToe_EdcLk01").item(0).getChildNodes();
-
-        return new EdcLk01(xmlNodesToDocument(nodes, "voegZaakdocumentToe_EdcLk01"));
-    }
+//    public EdcLk01 getEdcLk01() {
+//        var nodes = body.getElementsByTagNameNS("http://www.stufstandaarden.nl/koppelvlak/zds0120", "voegZaakdocumentToe_EdcLk01").item(0).getChildNodes();
+//
+//        return new EdcLk01(xmlNodesToDocument(nodes, "voegZaakdocumentToe_EdcLk01"));
+//    }
 
 }

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Stuurgegevens.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Stuurgegevens.java
@@ -1,0 +1,18 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.STUF;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Stuurgegevens{
+
+    @XmlElement(namespace = STUF)
+    public Zender zender;
+
+    @XmlElement(namespace = STUF)
+    public Ontvanger ontvanger;
+
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/ZakLk01_v2.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/ZakLk01_v2.java
@@ -1,18 +1,15 @@
 package nl.haarlem.translations.zdstozgw.translation.zds.model;
-
 import lombok.Data;
-import nl.haarlem.translations.zdstozgw.utils.xpath.XpathDocument;
-import org.w3c.dom.Document;
 
 import javax.xml.bind.annotation.*;
-
 import java.util.List;
 
 import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.*;
 
-@XmlRootElement(namespace = ZKN, name="edcLk01")
+@Data
+@XmlRootElement(namespace = ZKN, name="zakLk01")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class EdcLk01 {
+public class ZakLk01_v2 {
 
     @XmlAccessorType(XmlAccessType.FIELD)
     public static class Object{
@@ -22,32 +19,23 @@ public class EdcLk01 {
         @XmlElement(namespace = ZKN)
         public String identificatie;
 
-        @XmlElement(namespace = ZKN, name="dct.omschrijving")
+        @XmlElement(namespace = ZKN)
         public String omschrijving;
 
         @XmlElement(namespace = ZKN)
-        public String formaat;
+        public String toelichting;
 
         @XmlElement(namespace = ZKN)
-        public String taal;
+        public String startdatum;
 
         @XmlElement(namespace = ZKN)
-        public Inhoud inhoud;
+        public String einddatumGepland;
 
         @XmlElement(namespace = ZKN)
-        public String auteur;
+        public String archiefnominatie;
 
         @XmlElement(namespace = ZKN)
-        public String creatiedatum;
-
-        @XmlElement(namespace = ZKN)
-        public String titel;
-
-        @XmlElement(namespace = ZKN)
-        public String vertrouwelijkAanduiding;
-
-        @XmlElement(namespace = ZKN, name="isRelevantVoor")
-        public GerelateerdeWrapper isRelevantVoor;
+        public String registratiedatum;
 
         @XmlElement(namespace = ZKN, name="isVan")
         public GerelateerdeWrapper isVan;
@@ -62,7 +50,7 @@ public class EdcLk01 {
 
 
     @XmlElement(namespace = ZKN, name="object")
-    public List<EdcLk01.Object> objects;
+    public List<Object> objects;
 
     @XmlElement(namespace = ZKN, name="stuurgegevens")
     public Stuurgegevens stuurgegevens;

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Zender.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/Zender.java
@@ -1,0 +1,20 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+import static nl.haarlem.translations.zdstozgw.translation.zds.model.namespace.Namespace.STUF;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Zender{
+
+    @XmlElement(namespace = STUF)
+    public String organisatie;
+
+    @XmlElement(namespace = STUF)
+    public String applicatie;
+
+    @XmlElement(namespace = STUF)
+    public String gebruiker;
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/namespace/Namespace.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/namespace/Namespace.java
@@ -1,0 +1,8 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model.namespace;
+
+public class Namespace {
+    public static final String ZKN = "http://www.egem.nl/StUF/sector/zkn/0310";
+    public static final String STUF = "http://www.egem.nl/StUF/StUF0301";
+    public static final String BG= "http://www.egem.nl/StUF/sector/bg/0310";
+    public static final String MIME= "http://www.w3.org/2005/05/xmlmime";
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/services/ZaakService.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/services/ZaakService.java
@@ -3,6 +3,7 @@ package nl.haarlem.translations.zdstozgw.translation.zds.services;
 import nl.haarlem.translations.zdstozgw.translation.ZaakTranslator;
 import nl.haarlem.translations.zdstozgw.translation.zds.model.EdcLk01;
 import nl.haarlem.translations.zdstozgw.translation.zds.model.ZakLk01;
+import nl.haarlem.translations.zdstozgw.translation.zds.model.ZakLk01_v2;
 import nl.haarlem.translations.zdstozgw.translation.zds.model.ZakLv01;
 import nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient;
 import nl.haarlem.translations.zdstozgw.translation.zgw.model.ZgwEnkelvoudigInformatieObject;
@@ -14,6 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.w3c.dom.Document;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Marshaller;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,9 +32,11 @@ public class ZaakService {
     @Autowired
     private ZaakTranslator zaakTranslator;
 
-    public ZgwZaak creeerZaak(ZakLk01 zakLk01) throws Exception {
+    public ZgwZaak creeerZaak(ZakLk01_v2 zakLk01) throws Exception {
 
-        zaakTranslator.setDocument(zakLk01.getDocument()).zdsZaakToZgwZaak();
+
+        //zaakTranslator.setDocument((Document) zakLk01).zdsZaakToZgwZaak();
+        zaakTranslator.setZakLk01(zakLk01).zdsZaakToZgwZaak();
 
         ZgwZaak zaak = zaakTranslator.getZgwZaak();
 
@@ -89,12 +94,12 @@ public class ZaakService {
     public ZgwZaakInformatieObject voegZaakDocumentToe(EdcLk01 edcLk01) throws Exception {
         ZgwZaakInformatieObject result = null;
 
-        zaakTranslator.setDocument(edcLk01.getDocument()).zdsDocumentToZgwDocument();
+        zaakTranslator.setEdcLk01(edcLk01).zdsDocumentToZgwDocument();
 
         ZgwEnkelvoudigInformatieObject zgwEnkelvoudigInformatieObject = zgwClient.addDocument(zaakTranslator.getZgwEnkelvoudigInformatieObject());
 
         if (zgwEnkelvoudigInformatieObject.getUrl() != null) {
-            String zaakUrl = getZaakUrl(getZaakIdentificatie(edcLk01));
+            String zaakUrl = getZaakUrl(edcLk01.objects.get(0).isRelevantVoor.gerelateerde.identificatie);
             result = addZaakInformatieObject(zgwEnkelvoudigInformatieObject, zaakUrl);
         } else {
             throw new Exception("Document not added");
@@ -102,9 +107,6 @@ public class ZaakService {
         return result;
     }
 
-    private String getZaakIdentificatie(EdcLk01 edcLk01) {
-        return edcLk01.getXpathDocument().getNodeValue("//zkn:object/zkn:isRelevantVoor/zkn:gerelateerde/zkn:identificatie");
-    }
 
     private ZgwZaakInformatieObject addZaakInformatieObject(ZgwEnkelvoudigInformatieObject doc, String zaakUrl) throws Exception {
         ZgwZaakInformatieObject result = null;

--- a/src/main/java/nl/haarlem/translations/zdstozgw/utils/XmlUtils.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/utils/XmlUtils.java
@@ -104,4 +104,18 @@ public class XmlUtils {
         }
         return result;
     }
+
+	public static Document getDocument(String template) {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        DocumentBuilder builder;
+        try {
+            builder = factory.newDocumentBuilder();
+            File f = new File(template);
+            return builder.parse(f);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return null;
+	}
 }

--- a/src/main/resources/application.properties_example
+++ b/src/main/resources/application.properties_example
@@ -7,3 +7,14 @@ openzaak.baseUrl = https://openzaak.local
 nl.haarlem.translations.zdstozgw.trustAllCerts = false
 
 nl.haarlem.translations.zdstozgw.enableJWTEntpoint = false
+
+#spring.datasource.initialize=true
+spring.datasource.url=jdbc:h2:./zdstozgw.db
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+# Enabling H2 Console on http://localhost:8080/h2-console
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.h2.console.settings.web-allow-others=false

--- a/src/main/resources/config.json_example
+++ b/src/main/resources/config.json_example
@@ -52,6 +52,13 @@
 	        "requestcontains": "",	        
 	        "template": "--template-zit-in-de-code--",
 	        "implementation": "nl.haarlem.translations.zdstozgw.convertor.impl.VoegZaakdocumentToe"
-	    }
+	    },
+		{	
+			"translation": "ZDS 1.1 GWS4all genereerDocumentIdentificatie_Di02",
+	        "soapaction": "http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02",
+	        "requestcontains": "<StUF:applicatie>GWS4all</StUF:applicatie>",
+	        "template": "src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/genereerDocumentIdentificatie_Du02.xml",
+	        "implementation": "nl.haarlem.translations.zdstozgw.convertor.impl.GenereerDocumentIdentificatie"
+	    }	    
 	]    
 }

--- a/src/main/resources/config.json_example
+++ b/src/main/resources/config.json_example
@@ -30,5 +30,28 @@
         "documentType" : "https://openzaak.local/catalogi/api/v1/informatieobjecttypen/b380e35f-3b10-4d76-81b5-58f8013dca4a",
         "omschrijving" : "Overig stuk inkomend"
       }
-    ]
+    ],
+	"translations": [
+		{	
+			"translation": "ZDS 1.1 GWS4all genereerZaakIdentificatie_Di02",
+	        "soapaction": "http://www.egem.nl/StUF/sector/zkn/0310/genereerZaakIdentificatie_Di02",
+	        "requestcontains": "<StUF:applicatie>GWS4all</StUF:applicatie>",
+	        "template": "src/main/java/nl/haarlem/translations/zdstozgw/convertor/impl/genereerZaakIdentificatie_Du02.xml",
+	        "implementation": "nl.haarlem.translations.zdstozgw.convertor.impl.GenereerZaakIdentificatie"
+	    },
+	    {
+	        "translation": "ZDS 1.1 creeerZaak_Lk01",
+	        "soapaction": "http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01",
+	        "requestcontains": "",
+	        "template": "--template-zit-in-de-code--",
+	        "implementation": "nl.haarlem.translations.zdstozgw.convertor.impl.CreeerZaak"
+	    },
+	    {
+	        "translation": "ZDS 1.1 voegZaakdocumentToe_Lk01",
+	        "soapaction": "http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01",
+	        "requestcontains": "",	        
+	        "template": "--template-zit-in-de-code--",
+	        "implementation": "nl.haarlem.translations.zdstozgw.convertor.impl.VoegZaakdocumentToe"
+	    }
+	]    
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,14 @@
+-- Used by nl.haarlem.translations.zdstozgw.convertor.impl.GenereerZaakIdentificatie 
+INSERT INTO application_parameter (parameter_name, parameter_description, parameter_value)  
+SELECT 'ZaakIdentificatiePrefix', 'De prefix die wordt gebruikt bij de zaakidentificaties in nl.haarlem.translations.zdstozgw.convertor.impl.GenereerZaakIdentificatie', '1900'
+WHERE ( SELECT COUNT(*) FROM application_parameter WHERE parameter_name = 'ZaakIdentificatiePrefix') = 0;
+INSERT INTO application_parameter (parameter_name, parameter_description, parameter_value)  
+SELECT 'ZaakIdentificatieHuidige', 'Het laatste volgnummer dat is gebruikt voor de zaakidentificatie in nl.haarlem.translations.zdstozgw.convertor.impl.GenereerZaakIdentificatie', '1'
+WHERE ( SELECT COUNT(*) FROM application_parameter WHERE parameter_name = 'ZaakIdentificatieHuidige') = 0;
+-- Used by nl.haarlem.translations.zdstozgw.convertor.impl.GenereerDocumentIdentificatie
+INSERT INTO application_parameter (parameter_name, parameter_description, parameter_value)  
+SELECT 'DocumentIdentificatiePrefix', 'De prefix die wordt gebruikt bij de documentidentificaties in nl.haarlem.translations.zdstozgw.convertor.impl.GenereerDocumentIdentificatie', '1900'
+WHERE ( SELECT COUNT(*) FROM application_parameter WHERE parameter_name = 'DocumentIdentificatiePrefix') = 0;
+INSERT INTO application_parameter (parameter_name, parameter_description, parameter_value)  
+SELECT 'DocumentIdentificatieHuidige', 'Het laatste volgnummer dat is gebruikt voor de documentidentificatie in nl.haarlem.translations.zdstozgw.convertor.impl.GenereerDocumentIdentificatie', '1'
+WHERE ( SELECT COUNT(*) FROM application_parameter WHERE parameter_name = 'DocumentIdentificatieHuidige') = 0;


### PR DESCRIPTION
1 - Translation can be modified by the user (instead of the developer : ConvertorFactory uses config.json for implementation/template to load based upon soapaction / application-string
2 - The soapmethod GenereerZaakIdentificatie has been implemented (as proof of concept)
3 - Old Factorycode is still there for fallback